### PR TITLE
Api submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "knighthacks-api-js"]
+	path = knighthacks-api-js
+	url = https://github.com/KnightHacks/knighthacks-api-js

--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ docker run -itd -p 9090:9090 [--name <container_name>] <image_name>
 `-p 9090:9090` is required and based on the configured port in the Dockerfile and the NGINX config (default.config).
 
 You can now use the website through the url `http://localhost:9090` in your browser of choice.
+
+## Updating the API Submodule
+
+To get any changes made to the API submodule, run `git submodule update --remote`
+
+For a detailed guide of handling submodules, see [here](https://git-scm.com/book/en/v2/Git-Tools-Submodules)


### PR DESCRIPTION
In order to use the [knighthacks-api-js](https://github.com/KnightHacks/knighthacks-api-js) repo for common functions, I'm adding it to this repository as a git submodule. If we make changes to that library, we can run `git submodule update --remote` to pull any new changes to its main branch.